### PR TITLE
Hotfix 2017-05-10.1

### DIFF
--- a/src/com/modelo/Md5.java
+++ b/src/com/modelo/Md5.java
@@ -27,7 +27,7 @@ public class Md5 {
      */
     public String cifrar(String mensaje) throws NoSuchAlgorithmException {
 	MessageDigest md = MessageDigest.getInstance("MD5");
-	md.update("texto a cifrar".getBytes());
+	md.update(mensaje.getBytes());
 	byte[] digest = md.digest();
 
 	// Se escribe byte a byte en hexadecimal


### PR DESCRIPTION
El parámetro de mensaje recibido por la clase MD5 estaba siendo procesado internamente como un valor en duro. 
Ahora se procesa el mensaje que se le pasa en parámetro